### PR TITLE
Support & instructions for MPS (MacOS w/ GPU support on M1/M2) and CPU

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,19 @@
 
 ## Requirements
 
-Please follow the requirements of [https://github.com/NVlabs/stylegan3](https://github.com/NVlabs/stylegan3).
+If you have CUDA graphic card, please follow the requirements of [https://github.com/NVlabs/stylegan3](https://github.com/NVlabs/stylegan3).
+
+Otherwise (for GPU acceleration on MacOS with Silicon Mac M1/M2, or just CPU) try the following:
+
+```sh
+cat environment.yml | \
+  grep -v -E 'nvidia|cuda' > environment-no-nvidia.yml && \
+    conda env create -f environment-no-nvidia.yml
+conda activate stylegan3
+
+# On MacOS
+export PYTORCH_ENABLE_MPS_FALLBACK=1
+```
 
 ## Download pre-trained StyleGAN2 weights
 

--- a/environment.yml
+++ b/environment.yml
@@ -5,11 +5,12 @@ channels:
 dependencies:
   - python >= 3.8
   - pip
-  - numpy>=1.20
+  - numpy>=1.25
   - click>=8.0
-  - pillow=8.3.1
-  - scipy=1.7.1
-  - pytorch=1.9.1
+  - pillow=9.4.0
+  - scipy=1.11.0
+  - pytorch>=2.0.1
+  - torchvision>=0.15.2
   - cudatoolkit=11.1
   - requests=2.26.0
   - tqdm=4.62.2
@@ -17,8 +18,10 @@ dependencies:
   - matplotlib=3.4.2
   - imageio=2.9.0
   - pip:
-    - imgui==1.3.0
-    - glfw==2.2.0
+    - imgui==2.0.0
+    - glfw==2.6.1
+    - gradio==3.35.2
     - pyopengl==3.1.5
     - imageio-ffmpeg==0.4.3
-    - pyspng
+    # pyspng is currently broken on MacOS (see https://github.com/nurpax/pyspng/pull/6 for instance)
+    - pyspng-seunglab

--- a/stylegan_human/generate.py
+++ b/stylegan_human/generate.py
@@ -63,9 +63,10 @@ def generate_images(
 
     else: 
         import torch
-        device = torch.device('cuda')
+        device = torch.device('cuda' if torch.cuda.is_available() else 'mps' if torch.backends.mps.is_available() else 'cpu')
+        dtype = torch.float32 if device.type == 'mps' else torch.float64
         with dnnlib.util.open_url(network_pkl) as f:
-            G = legacy.load_network_pkl(f)['G_ema'].to(device) # type: ignore
+            G = legacy.load_network_pkl(f)['G_ema'].to(device, dtype=dtype) # type: ignore
     os.makedirs(outdir, exist_ok=True)
 
 
@@ -92,7 +93,7 @@ def generate_images(
 
         else: ## stylegan v2/v3
             label = torch.zeros([1, G.c_dim], device=device)
-            z = torch.from_numpy(np.random.RandomState(seed).randn(1, G.z_dim)).to(device)
+            z = torch.from_numpy(np.random.RandomState(seed).randn(1, G.z_dim)).to(device, dtype=dtype)
             if target_z.size==0:
                 target_z= z.cpu()
             else:

--- a/viz/renderer.py
+++ b/viz/renderer.py
@@ -69,7 +69,8 @@ def add_watermark_np(input_image_array, watermark_text="AI Generated"):
 
 class Renderer:
     def __init__(self, disable_timing=False):
-        self._device        = torch.device('cuda')
+        self._device        = torch.device('cuda' if torch.cuda.is_available() else 'mps' if torch.backends.mps.is_available() else 'cpu')
+        self._dtype         = torch.float32 if self._device.type == 'mps' else torch.float64
         self._pkl_data      = dict()    # {pkl: dict | CapturedException, ...}
         self._networks      = dict()    # {cache_key: torch.nn.Module, ...}
         self._pinned_bufs   = dict()    # {(shape, dtype): torch.Tensor, ...}
@@ -241,7 +242,7 @@ class Renderer:
 
         if self.w_load is None:
             # Generate random latents.
-            z = torch.from_numpy(np.random.RandomState(w0_seed).randn(1, 512)).to(self._device).float()
+            z = torch.from_numpy(np.random.RandomState(w0_seed).randn(1, 512)).to(self._device, dtype=self._dtype)
 
             # Run mapping network.
             label = torch.zeros([1, G.c_dim], device=self._device)


### PR DESCRIPTION
This makes most commands work (including `visualizer_drag_gradio.py`) on an M1/M2 Mac w/ GPU acceleration, except for the following:
*   `visualizer_drag.py`: some segfaults involving libffi + OpenGL (seems to crash inside `GlfwWindow.monitor_width` and then some more)
*   `stylegan_human/stylemixing_video.py`: couldn't sort out the dep to tensorflow, looks like it depends on a an old version that still had tensorflow.contrib

Should also work on any platform w/o CUDA using just the CPU.

Fixes https://github.com/XingangPan/DragGAN/issues/71