### PR TITLE
Open a port from docker container to local

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,8 +75,8 @@ Provided docker image is based on NGC PyTorch repository. To quickly try out vis
 
 ```sh
 docker build . -t draggan:latest  
-docker run -v  "$PWD":/workspace/src -it draggan:latest bash  
-cd src && python visualizer_drag_gradio.py  
+docker run -p 7860: 7860 -v "$PWD":/workspace/src -it draggan:latest bash  
+cd src && python visualizer_drag_gradio.py --listen
 ```
 Now you can open a shared link from Gradio (printed in the terminal console).   
 Beware the Docker image takes about 25GB of disk space!

--- a/visualizer_drag_gradio.py
+++ b/visualizer_drag_gradio.py
@@ -17,6 +17,11 @@ from viz.renderer import Renderer, add_watermark_np
 parser = ArgumentParser()
 parser.add_argument('--share', action='store_true',default='True')
 parser.add_argument('--cache-dir', type=str, default='./checkpoints')
+parser.add_argument(
+    "--listen",
+    action="store_true",
+    help="launch gradio with 0.0.0.0 as server name, allowing to respond to network requests",
+)
 args = parser.parse_args()
 
 cache_dir = args.cache_dir
@@ -863,4 +868,4 @@ with gr.Blocks() as app:
 
 gr.close_all()
 app.queue(concurrency_count=3, max_size=20)
-app.launch(share=args.share)
+app.launch(share=args.share, server_name="0.0.0.0" if args.listen else "127.0.0.1")


### PR DESCRIPTION
Gradio can accept network requests, instead using gradio ssh tunneling you can interact with gradio tool faster using docker ports