### PR TITLE
corrine add msvc path in sustom_ops.py

### DIFF
--- a/torch_utils/custom_ops.py
+++ b/torch_utils/custom_ops.py
@@ -32,6 +32,7 @@ def _find_compiler_bindir():
         'C:/Program Files*/Microsoft Visual Studio/*/BuildTools/VC/Tools/MSVC/*/bin/Hostx64/x64',
         'C:/Program Files*/Microsoft Visual Studio/*/Community/VC/Tools/MSVC/*/bin/Hostx64/x64',
         'C:/Program Files*/Microsoft Visual Studio */vc/bin',
+        'C:/ Program Files*/Microsoft Visual Studio/*/Preview/VC/Tools/MSVC/*/bin/Hostx64/x64',
     ]
     for pattern in patterns:
         matches = sorted(glob.glob(pattern))


### PR DESCRIPTION
![image](https://github.com/XingangPan/DragGAN/assets/137778687/152fb510-4611-4ec1-81c0-47ad5b1e3830)
I add a new cl.exe path to fix this error:
Could not find MSVC/GCC/CLANG installation on this computer.
Refer to:
https://github.com/RameenAbdal/StyleFlow/issues/13